### PR TITLE
Add IANA expert guidance

### DIFF
--- a/draft-ietf-tls-tlsflags.xml
+++ b/draft-ietf-tls-tlsflags.xml
@@ -15,6 +15,7 @@
 <!ENTITY RFC8174 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8174.xml">
 <!ENTITY RFC8446 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8446.xml">
 <!ENTITY RFC8126 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8126.xml">
+<!ENTITY RFC5746 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5746.xml">
 <!ENTITY I-D.sy-tls-resumption-group PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.sy-tls-resumption-group.xml">
 <!ENTITY I-D.ietf-tls-tls13-cert-with-extern-psk PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-tls-tls13-cert-with-extern-psk.xml">
 ]>
@@ -23,7 +24,7 @@
     <front>
         <title abbrev="TLS Flags">A Flags Extension for TLS 1.3</title>
         <author initials="Y." surname="Nir" fullname="Yoav Nir">
-            <organization >DellEMC</organization>
+            <organization >Dell Technologies</organization>
             <address>
                 <postal>
                     <street>9 Andrei Sakharov St</street>
@@ -156,6 +157,29 @@
             </t>
             <t> The policy for this shall be "Specification Required" as described in <xref
                 target="RFC8126"/>.</t>
+            <section anchor="ianaexp" title="Guidance for IANA Experts">
+                <t> This extension allows up to 2040 flags. However, they are not all the same, because the 
+                    length of the extension is determined by the highest set bit.</t>
+                <t> We would like to allocate the flags in such a way that the typical extension is as short
+                    as possible. The scenario we want to guard against is that in a few years some extension
+                    is defined that all implementations need to support and that is assigned a high number
+                    because all of the lower numbers have already been allocated. An example of such an 
+                    extension is the Renegotiation Indication Extension defined in <xref target="RFC5746"/>.</t>
+                <t> For this reason, the IANA experts should allocate the flags as follows:<list style="symbols">
+                    <t> Flags 0-7 are reserved for documents coming out of the TLS working group with a specific
+                        request to assign a low number.</t>
+                    <t> Flags 8-31 are for standards-track documents that the experts believe will see wide 
+                        adoption among either all users of TLS or a significant group of TLS users. For example,
+                        an extension that will be used by all web clients or all smart objects.</t>
+                    <t> Flags 32-63 are for other documents, including experimental, that are likely to see 
+                        significant adoption.</t>
+                    <t> Flags 64-79 are not to be allocated. They are for reserved for private use.</t>
+                    <t> Flags 80-2039 can be used for temporary allocation in experiments, for flags that are
+                        likely to see use only in very specific environments, for national and corporate
+                        extensions, and as overflow, in case one of the previous categories has been exhausted.</t>
+                    </list>
+                </t>
+            </section>
         </section>
         <section anchor="sec" title="Security Considerations">
             <t> The extension described in this document provides a more concise way to express data that could
@@ -170,7 +194,7 @@
                 Mavrogiannopoulos.</t>
             <t> Improvement to the encoding were suggested by Ilari Liusvaara, who also asked for a better 
                 explanation of the semantics of missing extensions.</t>
-            <t> Useful comments received from Martin Thomson.
+            <t> Useful comments received from Martin Thomson.</t>
         </section>
     </middle>
     <back>
@@ -181,13 +205,15 @@
         </references>
         <references title="Informative References">
             &RFC8126;
+            &RFC5746;
             &I-D.sy-tls-resumption-group;
             &I-D.ietf-tls-tls13-cert-with-extern-psk;
         </references>
         <section anchor="changelog" title="Change Log">
             <t> RFC EDITOR: PLEASE REMOVE THIS SECTION AS IT IS ONLY MEANT TO AID THE WORKING GROUP IN TRACKING
                 CHANGES TO THIS DOCUMENT.</t>
-            <t> draft-ietf-tls-tlsflags-02 set the maximum number of flags to 2048.
+            <t> draft-ietf-tls-tlsflags-02 set the maximum number of flags to 2048, and added guidance for
+                the IANA experts.</t>
             <t> draft-ietf-tls-tlsflags-01 allows server-only flags and allows the client to send an empty 
                 extension. Also modified the packing order of the bits.</t>
             <t> draft-ietf-tls-tlsflags-00 had the same text as draft-nir-tls-tlsflags-02, and was re-submitted


### PR DESCRIPTION
Provide guidance on what flag should be allocated to what extension, based on the likelihood of that extension being widely used.