### PR TITLE
Require abort on malformed extension

### DIFF
--- a/draft-ietf-tls-tlsflags.xml
+++ b/draft-ietf-tls-tlsflags.xml
@@ -150,6 +150,13 @@
             <t> A server MAY indicate support for flag-type features in a flags extension of NewSessionTicket (NST).
                 This message has no client-side response.</t>
             <t> In summary, unsolicited flags may appear only in ClientHello, CertificateRequest, and NewSessionTicket.</t>
+            <t> An implementation that receives an invalid tls_flags extension MUST terminate the TLS handshake with a
+                fatal illegal_parameter alert. Such invalid tls_flags extensions include: <list style="symbols">
+                <t> A zero-length extension</t>
+                <t> Multiple tls_flags extensions for the same message </t>
+                <t> A flag set in the tls_flags extension of the wrong message, as specified in the document for that flag </t>
+                <t> A flag set in a response that was not indicated in a reqeust </t>
+                <t> As mentioned previously, an extension with trailing zero-bytes </t></list></t>
         </section>
         <section anchor="iana" title="IANA Considerations">
             <t> IANA is requested to assign a new value from the TLS ExtensionType Values registry:


### PR DESCRIPTION
This is to address a comment by Michael StJohns on the mailing list. To quote:
```
Section 2 requires  (MUST) the generation of fatal illegal_parameter alert upon reception of 
a mal-encoded extension (e.g. any trailing zero bytes), but compare and contrast this with 
section 3 which is full of MUST and MUST NOT declarations but with no concrete actions to 
be taken.  E.g. if I (server or client) send 0x01 0x10, and receive 0x01 0x11 from the client 
or server, wouldn't that be an illegal value as I've added a bit not sent to me?   Should 
that cause the same fatal illegal_parameter alert? Alternately, "receiver MUST ignore 
received bits that weren't sent" language could clean this up.
```