### PR TITLE
Clarify language around the size of the extension.

### DIFF
--- a/draft-ietf-tls-tlsflags.xml
+++ b/draft-ietf-tls-tlsflags.xml
@@ -130,7 +130,7 @@
         </section>
         <section anchor="rules" title="Rules for The Flags Extension">
             <t> Any TLS implementation that intends to propose or indicate support for a flag extension SHALL send this
-                extension with the relevant bits set.  It MUST NOT send this extension empty -- with a length of zero.</t>
+                extension with the relevant bits set.</t>
             <t> This specification does not require every flag extension to be acknowledged. Acknowledging 
                    a flag extension is typically needed to inform the peer proposing the extension that the other 
                    side understands and supports the extension, but some extensions do not require this


### PR DESCRIPTION
The declarative syntax specifies that flags are <1..255>, and therefore can not be empty. If it does not conform to the syntax, we should fail with a decode error alert.

The MUST NOT implies that this is illegal for some other reason and therefore would require failing with an illegal parameter alert.

Since the MUST NOT is redundant with the declarative syntax as specified, just remove this.